### PR TITLE
Updating SVGLoader to handle comments

### DIFF
--- a/examples/js/loaders/SVGLoader.js
+++ b/examples/js/loaders/SVGLoader.js
@@ -25,7 +25,7 @@ THREE.SVGLoader.prototype = {
 
 			var doc = parser.parseFromString( svgString, 'image/svg+xml' );  // application/xml
 
-			onLoad( doc.firstChild );
+			onLoad( doc.documentElement );
 
 		}, onProgress, onError );
 


### PR DESCRIPTION
The documentElement will always return the svg node. Otherwise it used to fail, if there was a comment node before it. Comments are commonly seen when an svg is exported from Adobe Illustrator.